### PR TITLE
Perft benchmarks and tests + fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       working-directory: ./chusst-gen
-      run: cargo test --verbose
+      run: cargo test --release --verbose
     - name: Install React dependencies
       run: npm install
       if: startsWith(github.ref, 'refs/tags/')
@@ -66,7 +66,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       working-directory: ./chusst-gen
-      run: cargo test --verbose
+      run: cargo test --release --verbose
     - name: Install React dependencies
       run: npm install
     - name: Install Rust dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +445,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chess"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed299b171ec34f372945ad6726f7bc1d2afd5f59fb8380f64f48e2bab2f0ec8"
+dependencies = [
+ "arrayvec 0.5.2",
+ "failure",
+ "nodrop",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,11 +486,13 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "atty",
+ "chess",
  "colored",
  "divan",
  "lazy_static",
  "rand 0.8.5",
  "serde",
+ "shakmaty",
 ]
 
 [[package]]
@@ -961,6 +996,28 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -3003,6 +3060,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shakmaty"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2320d3932d5b410b2bdee568152b51f2373f018d3425dc7b424ab9b23a5d13"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bitflags 2.4.1",
+ "btoi",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,6 +3218,18 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
 
 [[package]]
 name = "system-deps"
@@ -3852,6 +3932,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,12 +257,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "bencher"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,8 +453,8 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "atty",
- "bencher",
  "colored",
+ "divan",
  "lazy_static",
  "rand 0.8.5",
  "serde",
@@ -499,6 +493,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -580,6 +575,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console-api"
@@ -865,6 +866,31 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "divan"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "dtoa"
@@ -2708,6 +2734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3461,16 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/chusst-gen/Cargo.toml
+++ b/chusst-gen/Cargo.toml
@@ -14,7 +14,9 @@ rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"] }
 
 [dev-dependencies]
+chess = "3.2.0"
 divan = "0.1.14"
+shakmaty = "0.27.0"
 
 [[bench]]
 name = "search"

--- a/chusst-gen/Cargo.toml
+++ b/chusst-gen/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"] }
 
 [dev-dependencies]
-bencher = "0.1.5"
+divan = "0.1.14"
 
 [[bench]]
 name = "search"

--- a/chusst-gen/benches/search.rs
+++ b/chusst-gen/benches/search.rs
@@ -1,29 +1,23 @@
+use divan::Bencher;
+
 use chusst_gen::eval::{Game, SilentSearchFeedback};
 use chusst_gen::game::BitboardGame;
 
-#[macro_use]
-extern crate bencher;
-
-use bencher::Bencher;
-
-fn search(bench: &mut Bencher) {
-    let mut searched = 0u64;
-    bench.iter(|| {
+#[divan::bench]
+fn search(bench: Bencher) {
+    bench.bench_local(|| {
         let game = BitboardGame::new();
 
         let best_branch = game
             .get_best_move_recursive(4, &mut (), &mut SilentSearchFeedback::default())
             .unwrap();
 
-        searched = u64::from(best_branch.searched);
+        best_branch.searched
     });
-
-    bench.bytes = searched;
 }
 
-fn perft4(bench: &mut Bencher) {
-    let mut searched = 0u64;
-
+#[divan::bench]
+fn perft4(bench: Bencher) {
     fn possible_moves_recursive(game: &BitboardGame, depth: u8) -> u64 {
         if depth == 0 {
             return 1;
@@ -41,13 +35,11 @@ fn perft4(bench: &mut Bencher) {
         count
     }
 
-    bench.iter(|| {
+    bench.bench_local(|| {
         let game = BitboardGame::new();
 
-        searched = possible_moves_recursive(&game, 4);
+        possible_moves_recursive(&game, 4)
     });
-
-    bench.bytes = searched;
 }
 
 fn game_benchmark() -> u64 {
@@ -104,13 +96,11 @@ fn game_benchmark() -> u64 {
     // );
 }
 
-fn game(bench: &mut Bencher) {
-    let mut searched = 0u64;
-    bench.iter(|| {
-        searched = game_benchmark();
-    });
-    bench.bytes = searched;
+#[divan::bench]
+fn game(bench: Bencher) {
+    bench.bench_local(game_benchmark);
 }
 
-benchmark_group!(benches, game, search, perft4);
-benchmark_main!(benches);
+fn main() {
+    divan::main();
+}

--- a/chusst-gen/benches/search.rs
+++ b/chusst-gen/benches/search.rs
@@ -21,6 +21,35 @@ fn search(bench: &mut Bencher) {
     bench.bytes = searched;
 }
 
+fn perft4(bench: &mut Bencher) {
+    let mut searched = 0u64;
+
+    fn possible_moves_recursive(game: &BitboardGame, depth: u8) -> u64 {
+        if depth == 0 {
+            return 1;
+        }
+
+        let mut count = 0;
+
+        let moves = game.get_all_possible_moves();
+        for mv in moves {
+            let mut game = game.clone();
+            game.do_move(&mv);
+            count += possible_moves_recursive(&game, depth - 1);
+        }
+
+        count
+    }
+
+    bench.iter(|| {
+        let game = BitboardGame::new();
+
+        searched = possible_moves_recursive(&game, 4);
+    });
+
+    bench.bytes = searched;
+}
+
 fn game_benchmark() -> u64 {
     // use std::io::Write;
 
@@ -83,5 +112,5 @@ fn game(bench: &mut Bencher) {
     bench.bytes = searched;
 }
 
-benchmark_group!(benches, game, search);
+benchmark_group!(benches, game, search, perft4);
 benchmark_main!(benches);

--- a/chusst-gen/src/eval.rs
+++ b/chusst-gen/src/eval.rs
@@ -267,6 +267,10 @@ trait GamePrivate<B: Board + SafetyChecks>: PlayableGame<B> + ModifiableGame<B> 
                 possible_moves.push(mva!(position, target));
                 possible_moves.push(MoveAction {
                     mv: mv!(position, target),
+                    move_type: MoveActionType::Promotion(PromotionPieces::Knight),
+                });
+                possible_moves.push(MoveAction {
+                    mv: mv!(position, target),
                     move_type: MoveActionType::Promotion(PromotionPieces::Bishop),
                 });
                 possible_moves.push(MoveAction {

--- a/chusst-gen/src/eval/tests.rs
+++ b/chusst-gen/src/eval/tests.rs
@@ -147,11 +147,10 @@ fn perft_compare_against_shakmaty(fen: &str, depth: u8) {
         .expect("Failed to convert FEN to position");
 
     fn perft_compare(
-        initial_game: &TestGame,
         chusst_game: TestGame,
         shakmaty_game: shakmaty::Chess,
         depth: u8,
-        moves: &[&MoveAction],
+        moves: &[&TestGame],
     ) {
         use shakmaty::Position;
         use std::collections::HashMap;
@@ -201,10 +200,12 @@ fn perft_compare_against_shakmaty(fen: &str, depth: u8) {
                 })
                 .collect::<Vec<_>>();
 
+            for game in moves {
+                println!("After:\n{}", game.board());
+            }
+
             panic!(
-                "Initial board:\n{}\nAfter moves: [{}]\nPlayer {} in board:\n{}\nChusst moves: [{}]\nShakmaty moves: [{}]\nMoves not in Shakmaty: [{}]\nMoves not in Chusst: [{}]\n                     [{}]",
-                initial_game.board(),
-                format_mv_list(moves.iter().copied()),
+                "Player {} in board:\n{}\nChusst moves: [{}]\nShakmaty moves: [{}]\nMoves not in Shakmaty: [{}]\nMoves not in Chusst: [{}]\n                     [{}]",
                 chusst_game.player(),
                 chusst_game.board(),
                 format_mv_list(chusst_moves.iter()),
@@ -216,7 +217,7 @@ fn perft_compare_against_shakmaty(fen: &str, depth: u8) {
         }
 
         for chusst_mv in chusst_moves.iter() {
-            let mut chusst_game = chusst_game.clone();
+            let mut new_chusst_game = chusst_game.clone();
             let mut shakmaty_game = shakmaty_game.clone();
             let shakmaty_mv = shakmaty_moves_map
                 .iter()
@@ -224,16 +225,16 @@ fn perft_compare_against_shakmaty(fen: &str, depth: u8) {
                 .unwrap()
                 .0;
 
-            chusst_game.do_move(chusst_mv);
+            new_chusst_game.do_move(chusst_mv);
             shakmaty_game.play_unchecked(shakmaty_mv);
 
-            let moves = Vec::from_iter(moves.iter().chain(&[chusst_mv]).copied());
+            let moves = Vec::from_iter(moves.iter().chain(&[&chusst_game]).copied());
 
-            perft_compare(initial_game, chusst_game, shakmaty_game, depth - 1, &moves);
+            perft_compare(new_chusst_game, shakmaty_game, depth - 1, &moves);
         }
     }
 
-    perft_compare(&chusst_game, chusst_game.clone(), shakmaty_game, depth, &[]);
+    perft_compare(chusst_game.clone(), shakmaty_game, depth, &[]);
 }
 
 #[test]

--- a/chusst-gen/src/eval/tests.rs
+++ b/chusst-gen/src/eval/tests.rs
@@ -559,8 +559,7 @@ fn fen_parsing() {
     assert_eq!(game, TestGame::new(), "\n{}", game.board());
 }
 
-#[test]
-fn perft() {
+fn perft_impl(force_comparison: bool) {
     fn mv_rec(game: &TestGame, depth: u8) -> u64 {
         if depth == 0 {
             return 1;
@@ -580,8 +579,14 @@ fn perft() {
         nodes
     }
 
-    fn assert_perft(fen: &str, name: &str, depth: u8, expected: u64) {
+    let assert_perft = |fen: &str, name: &str, depth: u8, expected: u64| {
         let game = game_from_fen(fen);
+
+        if force_comparison {
+            perft_compare_against_shakmaty(fen, depth);
+            return;
+        }
+
         let nodes = mv_rec(&game, depth);
         if nodes != expected {
             println!(
@@ -592,9 +597,9 @@ fn perft() {
 
             perft_compare_against_shakmaty(fen, depth);
 
-            panic!("Perft failed");
+            panic!("Perft failed"); // just in case the comparison didn't panic
         }
-    }
+    };
 
     let fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
@@ -634,6 +639,17 @@ fn perft() {
     assert_perft(fen, "position 6", 2, 2079);
     assert_perft(fen, "position 6", 3, 89890);
     assert_perft(fen, "position 6", 4, 3894594);
+}
+
+#[test]
+fn perft() {
+    perft_impl(false);
+}
+
+#[test]
+#[ignore]
+fn perft_slow() {
+    perft_impl(true);
 }
 
 // Template to quickly test a specific board/move

--- a/chusst-gen/src/game/play.rs
+++ b/chusst-gen/src/game/play.rs
@@ -89,6 +89,8 @@ impl<B: Board> ModifiableGame<B> for GameState<B> {
             _ => MoveExtraInfo::Other,
         };
 
+        let captured = self.board.at(&mv.target);
+
         self.move_piece(&mv.source, &mv.target);
 
         match move_info {
@@ -132,6 +134,16 @@ impl<B: Board> ModifiableGame<B> for GameState<B> {
                 0 => self.disable_castle_queenside(player),
                 7 => self.disable_castle_kingside(player),
                 _ => (),
+            }
+        }
+
+        if let Some(captured) = captured {
+            if captured.piece == PieceType::Rook && mv.target.rank == B::home_rank(&captured.player) {
+                match mv.target.file {
+                    0 => self.disable_castle_queenside(captured.player),
+                    7 => self.disable_castle_kingside(captured.player),
+                    _ => (),
+                }
             }
         }
 


### PR DESCRIPTION
* Use Divan for benchmarks.
* Add perft4 benchmarks and compare against Shakmaty and Rust-Chess.
* Add perft1-4 tests and compare against Shakmaty.
* Fix: missing promotion to knight in move generation.
* Fix: disable castling right when rook is captured.